### PR TITLE
Add qcom-preflight-checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,9 @@ updates:
       dev-deps:
         patterns: ["*"]
         update-types: ["patch"]
+
+  - target-branch: "qcom-next"
+    package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # This points to .github/workflows
+    schedule:
+      interval: "daily"

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,0 +1,24 @@
+name: Qualcomm Preflight Checks
+on:
+  pull_request_target:
+    branches: [ "qcom-next" ]
+  push:
+    branches: [ "qcom-next" ]
+  workflow_dispatch:
+
+permissions:
+ contents: read
+ security-events: write
+
+jobs:
+  qcom-preflight-checks:
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+    with:
+        # ✅ Preflight Checkers
+        repolinter: true                   # default: true
+        semgrep: true                      # default: true
+        copyright-license-detector: true   # default: true
+        pr-check-emails: true              # default: true
+        dependency-review: true            # default: true
+    secrets:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,27 @@
+name: 'Close stale issues and pull requests with no recent activity'
+on:
+  schedule:
+  - cron: "15 00 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment, otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as a stale pull request because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment, otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
+        stale-issue-label: Stale
+        stale-pr-label: Stale
+        exempt-issue-labels: bug,enhancement
+        exempt-pr-labels: bug,enhancement
+        days-before-stale: 30
+        days-before-close: 5
+        remove-stale-when-updated: true
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Summary
qcom-preflight-checks calls a [reusable-workflow](https://github.com/qualcomm/qcom-reusable-workflows/blob/main/.github/workflows/qcom-preflight-checks-reusable-workflow.yml) that runs a series of preflight checks on your proposed contribution.

For more info check https://github.com/qualcomm/qcom-actions/blob/main/README.md