### PR TITLE
qti: Add initial TF-A BL2 and BL31 support for Lemans

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -568,6 +568,9 @@ subsections:
           - title: RB3Gen2
             scope: rb3gen2
 
+          - title: Lemans
+            scope: lemans
+
       - title: Raspberry Pi
         scope: rpi
 

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -571,6 +571,9 @@ subsections:
           - title: Lemans
             scope: lemans
 
+          - title: Lemans EVK
+            scope: lemans_evk
+
       - title: Raspberry Pi
         scope: rpi
 

--- a/plat/qti/lemans/inc/lemans_def.h
+++ b/plat/qti/lemans/inc/lemans_def.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef LEMANS_DEF_H
+#define LEMANS_DEF_H
+
+#include <common_def.h>
+
+#include <qti_board_def.h>
+#include <qtiseclib_defs_plat.h>
+
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/*
+ * MPIDR_PRIMARY_CPU
+ * You just need to have the correct core_affinity_val i.e. [7:0]
+ * and cluster_affinity_val i.e. [15:8]
+ * the other bits will be ignored
+ */
+/*----------------------------------------------------------------------------*/
+#define MPIDR_PRIMARY_CPU		0x0000
+/*----------------------------------------------------------------------------*/
+
+#define QTI_PWR_LVL0			MPIDR_AFFLVL0
+#define QTI_PWR_LVL1			MPIDR_AFFLVL1
+#define QTI_PWR_LVL2			MPIDR_AFFLVL2
+#define QTI_PWR_LVL3			MPIDR_AFFLVL3
+
+/*
+ *  Macros for local power states encoded by State-ID field
+ *  within the power-state parameter.
+ */
+/* Local power state for power domains in Run state. */
+#define QTI_LOCAL_STATE_RUN		0
+/*
+ * Local power state for clock-gating. Valid only for CPU and not cluster power
+ * domains
+ */
+#define QTI_LOCAL_STATE_STB		1
+/*
+ * Local power state for retention. Valid for CPU and cluster power
+ * domains
+ */
+#define QTI_LOCAL_STATE_RET		2
+/*
+ * Local power state for OFF/power down. Valid for CPU, cluster, RSC and PDC
+ * power domains
+ */
+#define QTI_LOCAL_STATE_OFF		3
+/*
+ * Local power state for DEEPOFF/power rail down. Valid for CPU, cluster and RSC
+ * power domains
+ */
+#define QTI_LOCAL_STATE_DEEPOFF		4
+
+/*
+ * This macro defines the deepest retention state possible. A higher state
+ * id will represent an invalid or a power down state.
+ */
+#define PLAT_MAX_RET_STATE		QTI_LOCAL_STATE_RET
+
+/*
+ * This macro defines the deepest power down states possible. Any state ID
+ * higher than this is invalid.
+ */
+#define PLAT_MAX_OFF_STATE		QTI_LOCAL_STATE_DEEPOFF
+
+/******************************************************************************
+ * Required platform porting definitions common to all ARM standard platforms
+ *****************************************************************************/
+
+/*
+ * Platform specific page table and MMU setup constants.
+ */
+#define MAX_MMAP_REGIONS		(PLAT_QTI_MMAP_ENTRIES)
+
+#define PLAT_PHY_ADDR_SPACE_SIZE	(1ull << 36)
+#define PLAT_VIRT_ADDR_SPACE_SIZE	(1ull << 36)
+
+#define ARM_CACHE_WRITEBACK_SHIFT	6
+
+/*
+ * Some data must be aligned on the biggest cache line size in the platform.
+ * This is known only to the platform as it might have a combination of
+ * integrated and external caches.
+ */
+#define CACHE_WRITEBACK_GRANULE		(1 << ARM_CACHE_WRITEBACK_SHIFT)
+
+/*
+ * One cache line needed for bakery locks on ARM platforms
+ */
+#define PLAT_PERCPU_BAKERY_LOCK_SIZE	(1 * CACHE_WRITEBACK_GRANULE)
+
+/*----------------------------------------------------------------------------*/
+/* PSCI power domain topology definitions */
+/*----------------------------------------------------------------------------*/
+/* One domain each to represent RSC and PDC level */
+#define PLAT_PDC_COUNT			1
+#define PLAT_RSC_COUNT			1
+
+/* There is one top-level FCM cluster */
+#define PLAT_CLUSTER_COUNT		1
+
+/* No. of cores in the FCM cluster */
+#define PLAT_CLUSTER0_CORE_COUNT	8
+
+#define PLATFORM_CORE_COUNT		(PLAT_CLUSTER0_CORE_COUNT)
+
+#define PLAT_NUM_PWR_DOMAINS		(PLAT_PDC_COUNT + \
+					 PLAT_RSC_COUNT + \
+					 PLAT_CLUSTER_COUNT + \
+					 PLATFORM_CORE_COUNT)
+
+#define PLAT_MAX_PWR_LVL		3
+
+/*****************************************************************************/
+/* Memory mapped I/O  */
+/*****************************************************************************/
+
+/*----------------------------------------------------------------------------*/
+/* GIC-600 constants */
+/*----------------------------------------------------------------------------*/
+#define BASE_GICD_BASE			0x17A00000
+#define BASE_GICR_BASE			0x17A60000
+#define BASE_GICC_BASE			0x0
+#define BASE_GICH_BASE			0x0
+#define BASE_GICV_BASE			0x0
+
+#define QTI_GICD_BASE			BASE_GICD_BASE
+#define QTI_GICR_BASE			BASE_GICR_BASE
+#define QTI_GICC_BASE			BASE_GICC_BASE
+
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* UART related constants. */
+/*----------------------------------------------------------------------------*/
+#define PLAT_QTI_UART_BASE			0xa8c000
+/* BASE ADDRESS OF DIFFERENT REGISTER SPACES IN HW */
+#define GENI4_CFG				0x0
+#define GENI4_IMAGE_REGS			0x100
+#define GENI4_DATA				0x600
+
+/* COMMON STATUS/CONFIGURATION REGISTERS AND MASKS */
+#define GENI_STATUS_REG				(GENI4_CFG + 0x00000040)
+#define GENI_STATUS_M_GENI_CMD_ACTIVE_MASK	(0x1)
+#define UART_TX_TRANS_LEN_REG			(GENI4_IMAGE_REGS + 0x00000170)
+/* MASTER/TX ENGINE REGISTERS */
+#define GENI_M_CMD0_REG				(GENI4_DATA + 0x00000000)
+/* FIFO, STATUS REGISTERS AND MASKS */
+#define GENI_TX_FIFOn_REG			(GENI4_DATA + 0x00000100)
+
+#define GENI_M_CMD_TX				(0x08000000)
+
+/*----------------------------------------------------------------------------*/
+/* Peripherals base addresses */
+/*----------------------------------------------------------------------------*/
+#define QTI_SEC_PRNG_BASE			0x10D0000
+
+/*----------------------------------------------------------------------------*/
+/* Device address space for mapping. Excluding starting 4K */
+/*----------------------------------------------------------------------------*/
+#define QTI_DEVICE_BASE				0x1000
+#define QTI_DEVICE_SIZE				(0x1C000000 - QTI_DEVICE_BASE)
+
+/*----------------------------------------------------------------------------*/
+/* AOSS registers */
+/*----------------------------------------------------------------------------*/
+#define QTI_PS_HOLD_REG				0x0C264000
+/*----------------------------------------------------------------------------*/
+/* AOP CMD DB  address space for mapping */
+/*----------------------------------------------------------------------------*/
+#define QTI_AOP_CMD_DB_BASE			0x90860000
+#define QTI_AOP_CMD_DB_SIZE			0x00020000
+/*----------------------------------------------------------------------------*/
+/* SOC hw version register */
+/*----------------------------------------------------------------------------*/
+#define QTI_SOC_VERSION_MASK			U(0xFFFF)
+#define QTI_SOC_REVISION_REG			0x1FC8000
+#define QTI_SOC_REVISION_MASK			U(0xFFFF)
+/*----------------------------------------------------------------------------*/
+/* LC PON register offsets */
+/*----------------------------------------------------------------------------*/
+#define PON_PS_HOLD_RESET_CTL			0x852
+#define PON_PS_HOLD_RESET_CTL2			0x853
+/*----------------------------------------------------------------------------*/
+/* APSS HM registers */
+/*----------------------------------------------------------------------------*/
+#define QTI_APSS_HM_BASE			0x17800000
+#define QTI_APSS_HM_SIZE			0x00d99000
+/*----------------------------------------------------------------------------*/
+/* AOSS registers */
+/*----------------------------------------------------------------------------*/
+#define QTI_AOSS_BASE				0x0b000000
+#define QTI_AOSS_SIZE				0x04000000
+/*----------------------------------------------------------------------------*/
+/* CORE_TOP_CSR */
+/*----------------------------------------------------------------------------*/
+#define QTI_CORE_TOP_CSR_BASE			0x01f00000
+#define QTI_CORE_TOP_CSR_BASE_SIZE		0x00100000
+/*----------------------------------------------------------------------------*/
+#endif /* LEMANS_DEF_H */

--- a/plat/qti/lemans/inc/qti_map_chipinfo.h
+++ b/plat/qti/lemans/inc/qti_map_chipinfo.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef QTI_MAP_CHIPINFO_H
+#define QTI_MAP_CHIPINFO_H
+
+#include <stdint.h>
+
+#include <qti_plat.h>
+
+#define QTI_JTAG_ID_REG                         0x786130
+#define QTI_JTAG_ID_SHIFT                       12
+#define QTI_DEFAULT_CHIPINFO_ID                 U(0xFFFF)
+
+static const chip_id_info_t g_map_jtag_chipinfo_id[] = {
+};
+#endif /* QTI_MAP_CHIPINFO_H */

--- a/plat/qti/lemans/inc/qti_secure_io_cfg.h
+++ b/plat/qti/lemans/inc/qti_secure_io_cfg.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef QTI_SECURE_IO_CFG_H
+#define QTI_SECURE_IO_CFG_H
+
+#include <stdint.h>
+
+/*
+ * List of peripheral/IO memory areas that are protected from
+ * non-secure world but not required to be secure.
+ */
+
+#define EUD_MODE_MANAGER2_EN			0x088E3000
+#define APPS_SMMU_TBU_PWR_STATUS		0x15002204
+#define APPS_SMMU_CUSTOM_CFG			0x15002300
+#define APPS_SMMU_STATS_SYNC_INV_TBU_ACK	0x150025DC
+#define APPS_SMMU_SAFE_SEC_CFG			0x15002648
+#define APPS_SMMU_MMU2QSS_AND_SAFE_WAIT_CNTR	0x15002670
+
+static const uintptr_t qti_secure_io_allowed_regs[] = {
+	EUD_MODE_MANAGER2_EN,
+	APPS_SMMU_TBU_PWR_STATUS,
+	APPS_SMMU_CUSTOM_CFG,
+	APPS_SMMU_STATS_SYNC_INV_TBU_ACK,
+	APPS_SMMU_SAFE_SEC_CFG,
+	APPS_SMMU_MMU2QSS_AND_SAFE_WAIT_CNTR,
+};
+
+#endif /* QTI_SECURE_IO_CFG_H */

--- a/plat/qti/lemans/lemans_evk/inc/platform_def.h
+++ b/plat/qti/lemans/lemans_evk/inc/platform_def.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef PLATFORM_DEF_H
+#define PLATFORM_DEF_H
+
+#include <lemans_def.h>
+
+#define MAX_IO_HANDLES			2
+#define MAX_IO_DEVICES			2
+#define MAX_IO_BLOCK_DEVICES		U(1)
+
+#define BL2_BASE			0x14680000
+#define BL2_SIZE			0x80000
+#define BL2_LIMIT			(BL2_BASE + BL2_SIZE)
+
+#define BL31_BASE			0x1c200000
+#define BL31_SIZE			0x00100000
+#define BL31_LIMIT			(BL31_BASE + BL31_SIZE)
+
+#define BL32_BASE			0x1c300000
+#define BL32_SIZE			0x00200000
+#define BL32_LIMIT			(BL32_BASE + BL32_SIZE)
+
+#define BL33_BASE			0xaf400000
+#define BL33_SIZE			0x00400000
+
+#define PLAT_QTI_FIP_IOBASE		0xaf000000
+#define PLAT_QTI_FIP_MAXSIZE		0x00400000
+
+#endif /* PLATFORM_DEF_H */

--- a/plat/qti/lemans/lemans_evk/platform.mk
+++ b/plat/qti/lemans/lemans_evk/platform.mk
@@ -1,0 +1,120 @@
+#
+# Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Makefile for Lemans based QCS9075/EVK QTI platform.
+
+PLAT_PATH				:=	plat/qti
+CHIPSET					:=	lemans
+
+RESET_TO_BL2				:=	1
+
+# Turn On Separate code & data.
+SEPARATE_CODE_AND_RODATA		:=	1
+USE_COHERENT_MEM			:=	0
+WARMBOOT_ENABLE_DCACHE_EARLY		:=	1
+HW_ASSISTED_COHERENCY			:=	1
+
+#Enable errata configs for cortex_a78c
+ERRATA_A78C_2242638			:=	1
+ERRATA_A78C_2376749			:=	1
+ERRATA_A78C_2395411			:=	1
+ERRATA_A78C_2683027			:=	1
+ERRATA_A78C_2712575			:=	1
+ERRATA_A78C_2743232			:=	1
+ERRATA_A78C_2772121			:=	1
+ERRATA_A78C_2779484			:=	1
+
+# Enable PSCI v1.0 extended state ID format
+PSCI_EXTENDED_STATE_ID			:=	1
+ARM_RECOM_STATE_ID_ENC 			:=	1
+PSCI_OS_INIT_MODE			:=	1
+
+# GIC-600 configuration
+GICV3_SUPPORT_GIC600			:=	1
+
+COLD_BOOT_SINGLE_CPU			:=	1
+PROGRAMMABLE_RESET_ADDRESS		:=	1
+
+# Enable XPU bypass
+QTI_MSM_XPU_BYPASS			:=	1
+$(eval $(call add_define,QTI_MSM_XPU_BYPASS))
+
+# Enable the dynamic translation tables library
+PLAT_XLAT_TABLES_DYNAMIC		:=	1
+$(eval $(call add_define,PLAT_XLAT_TABLES_DYNAMIC))
+
+#disable CTX_INCLUDE_AARCH32_REGS to support lemans gold cores
+override CTX_INCLUDE_AARCH32_REGS	:=	0
+WORKAROUND_CVE_2017_5715		:=      0
+DYNAMIC_WORKAROUND_CVE_2018_3639	:=      1
+# Enable stack protector.
+ENABLE_STACK_PROTECTOR := strong
+
+PLAT_INCLUDES		:=	-Iinclude/plat/common/					\
+				-I${PLAT_PATH}/${CHIPSET}/inc				\
+				-I${PLAT_PATH}/${CHIPSET}/${PLAT}/inc			\
+				-I${PLAT_PATH}/common/inc				\
+				-I${PLAT_PATH}/common/inc/$(ARCH)			\
+				-I${PLAT_PATH}/qtiseclib/inc				\
+				-I${PLAT_PATH}/qtiseclib/inc/${CHIPSET}
+
+include lib/xlat_tables_v2/xlat_tables.mk
+PLAT_BL_COMMON_SOURCES	+=	common/desc_image_load.c				\
+				drivers/qti/crypto/rng.c				\
+				drivers/qti/accesscontrol/xpu.c				\
+				lib/cpus/aarch64/cortex_a78c.S				\
+				lib/bl_aux_params/bl_aux_params.c			\
+				plat/common/aarch64/crash_console_helpers.S		\
+				$(PLAT_PATH)/common/src/$(ARCH)/qti_uart_console.S	\
+				$(PLAT_PATH)/common/src/qti_stack_protector.c		\
+				$(PLAT_PATH)/common/src/qti_common.c			\
+				${XLAT_TABLES_LIB_SRCS}
+
+BL2_SOURCES		+=	drivers/io/io_fip.c					\
+				drivers/io/io_memmap.c					\
+				drivers/io/io_storage.c					\
+				$(PLAT_PATH)/common/src/$(ARCH)/qti_bl2_helpers.S	\
+				$(PLAT_PATH)/common/src/qti_bl2_setup.c			\
+				$(PLAT_PATH)/common/src/qti_image_desc.c		\
+				$(PLAT_PATH)/common/src/qti_io_storage.c
+
+include drivers/arm/gic/v3/gicv3.mk
+BL31_SOURCES		+=	drivers/delay_timer/generic_delay_timer.c		\
+				drivers/delay_timer/delay_timer.c			\
+				plat/common/plat_gicv3.c				\
+				${GICV3_SOURCES}					\
+				plat/common/plat_psci_common.c				\
+				$(PLAT_PATH)/common/src/$(ARCH)/qti_helpers.S		\
+				$(PLAT_PATH)/common/src/pm_ps_hold.c			\
+				$(PLAT_PATH)/common/src/qti_bl31_setup.c		\
+				$(PLAT_PATH)/common/src/qti_gic_v3.c			\
+				$(PLAT_PATH)/common/src/qti_interrupt_svc.c		\
+				$(PLAT_PATH)/common/src/qti_syscall.c			\
+				$(PLAT_PATH)/common/src/qti_topology.c			\
+				$(PLAT_PATH)/common/src/qti_pm.c			\
+				$(PLAT_PATH)/common/src/spmi_arb.c			\
+				$(PLAT_PATH)/qtiseclib/src/qtiseclib_cb_interface.c
+
+BL31_SOURCES	+=		drivers/qti/sec_core/sec_core_stub.c \
+				drivers/qti/qtimer/qtimer_stub.c \
+				drivers/qti/watchdog/watchdog_stub.c \
+				drivers/qti/accesscontrol/access_control_stub.c
+
+# Override this on the command line to point to the qtiseclib library
+QTISECLIB_PATH ?=
+
+ifeq ($(QTISECLIB_PATH),)
+# if No lib then use stub implementation for qtiseclib interface
+$(warning QTISECLIB_PATH is not provided while building, using stub implementation. \
+		Please refer to documentation for more details \
+		THIS FIRMWARE WILL NOT BOOT!)
+BL31_SOURCES	+=	plat/qti/qtiseclib/src/qtiseclib_interface_stub.c
+else
+$(eval $(call add_define,QTISECLIB_PATH))
+# use library provided by QTISECLIB_PATH
+LDFLAGS += -L $(dir $(QTISECLIB_PATH))
+LDLIBS += -l$(patsubst lib%.a,%,$(notdir $(QTISECLIB_PATH)))
+endif

--- a/plat/qti/qtiseclib/inc/lemans/qtiseclib_defs_plat.h
+++ b/plat/qti/qtiseclib/inc/lemans/qtiseclib_defs_plat.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-2021, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __QTISECLIB_DEFS_PLAT_H__
+#define __QTISECLIB_DEFS_PLAT_H__
+
+#define QTISECLIB_PLAT_CLUSTER_COUNT	1
+#define QTISECLIB_PLAT_CORE_COUNT	8
+
+/*----------------------------------------------------------------------------*/
+/* AOP CMD DB  address space for mapping */
+/*----------------------------------------------------------------------------*/
+#define QTI_AOP_CMD_DB_BASE			0x90860000
+#define QTI_AOP_CMD_DB_SIZE			0x00020000
+
+/* Chipset specific secure interrupt number/ID defs. */
+#define QTISECLIB_INT_ID_SEC_WDOG_BARK			(0x204)
+#define QTISECLIB_INT_ID_NON_SEC_WDOG_BITE		(0x21)
+
+#define QTISECLIB_INT_ID_VMIDMT_ERR_CLT_SEC		(0xE6)
+#define QTISECLIB_INT_ID_VMIDMT_ERR_CLT_NONSEC		(0xE7)
+#define QTISECLIB_INT_ID_VMIDMT_ERR_CFG_SEC		(0xE8)
+#define QTISECLIB_INT_ID_VMIDMT_ERR_CFG_NONSEC		(0xE9)
+
+#define QTISECLIB_INT_ID_XPU_SEC			(0xE3)
+#define QTISECLIB_INT_ID_XPU_NON_SEC			(0xE4)
+
+//NOC INterrupt
+#define QTISECLIB_INT_ID_A1_NOC_ERROR			(0xC9)
+#define QTISECLIB_INT_ID_A2_NOC_ERROR			(0xEA)
+#define QTISECLIB_INT_ID_CONFIG_NOC_ERROR		(0xE2)
+#define QTISECLIB_INT_ID_DC_NOC_ERROR			(0x122)
+#define QTISECLIB_INT_ID_MEM_NOC_ERROR			(0x6C)
+#define QTISECLIB_INT_ID_SYSTEM_NOC_ERROR		(0xC8)
+#define QTISECLIB_INT_ID_MMSS_NOC_ERROR			(0xBA)
+#define QTISECLIB_INT_ID_LPASS_AGNOC_ERROR		(0x143)
+#define QTISECLIB_INT_ID_NSP_NOC_ERROR			(0x1CE)
+
+#endif /* __QTISECLIB_DEFS_PLAT_H__ */

--- a/plat/qti/qtiseclib/src/qtiseclib_interface_stub.c
+++ b/plat/qti/qtiseclib/src/qtiseclib_interface_stub.c
@@ -70,8 +70,7 @@ void qtiseclib_kryo6_silver_reset_asm(void)
 void qtiseclib_bl31_platform_setup(void)
 {
 	ERROR("Please use QTISECLIB_PATH while building TF-A\n");
-	ERROR("Please refer docs/plat/qti.rst for more details.\n");
-	panic();
+	ERROR("Please refer docs/plat/qti/* for more details.\n");
 }
 
 void qtiseclib_invoke_isr(uint32_t irq, void *handle)


### PR DESCRIPTION
OP-TEE OS support for Lemans should be part of this commit: https://github.com/b49020/optee_os/commit/9781fbce2e6ada416337b3dfb85220c54e81062c

With that the boot on Lemans without QTISECLIB can progress up-to here:

```
<XBL logs snipped>
...
NOTICE:  BL2: v2.14.0(release):v2.13.0-1298-ged62863d8
NOTICE:  BL2: Built : 17:34:55, Dec 24 2025
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.14.0(release):v2.13.0-1298-ged62863d8
NOTICE:  BL31: Built : 17:34:54, Dec 24 2025
ERROR:   Please use QTISECLIB_PATH while building TF-A
ERROR:   Please refer docs/plat/qti/* for more details.
I/TC:
I/TC: OP-TEE version: 4.8.0-82-g9781fbce2 (gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)) #1 Wed Dec 24 12:04:53 UTC 2025arch64
I/TC: WARNING: This OP-TEE configuration might be insecure!
I/TC: WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html
I/TC: Primary CPU initializing
I/TC: Platform Qualcomm: Flavor lemans
I/TC: Primary CPU switching to normal world boot
PANIC at PC : 0x000000001c2010c0
```