### PR TITLE
fix(qti): Don't fail to write dload mode register

### DIFF
--- a/plat/qti/kodiak/inc/qti_secure_io_cfg.h
+++ b/plat/qti/kodiak/inc/qti_secure_io_cfg.h
@@ -12,13 +12,13 @@
  * List of peripheral/IO memory areas that are protected from
  * non-secure world but not required to be secure.
  */
-
 #define EUD_MODE_MANAGER2_EN			0x088E2000
 #define APPS_SMMU_TBU_PWR_STATUS		0x15002204
 #define APPS_SMMU_CUSTOM_CFG			0x15002300
 #define APPS_SMMU_STATS_SYNC_INV_TBU_ACK	0x150025DC
 #define APPS_SMMU_SAFE_SEC_CFG			0x15002648
 #define APPS_SMMU_MMU2QSS_AND_SAFE_WAIT_CNTR	0x15002670
+#define TCSR_BOOT_MISC_DETECT			0x1FD3000
 
 static const uintptr_t qti_secure_io_allowed_regs[] = {
 	EUD_MODE_MANAGER2_EN,
@@ -27,6 +27,7 @@ static const uintptr_t qti_secure_io_allowed_regs[] = {
 	APPS_SMMU_STATS_SYNC_INV_TBU_ACK,
 	APPS_SMMU_SAFE_SEC_CFG,
 	APPS_SMMU_MMU2QSS_AND_SAFE_WAIT_CNTR,
+	TCSR_BOOT_MISC_DETECT,
 };
 
 #endif /* QTI_SECURE_IO_CFG_H */


### PR DESCRIPTION
On the Kodiak platform, setting download mode fails with "failed to set download mode: -22". This is because the memmap address of TCSR_BOOT_MISC_DETECT is not in qti_secure_io_allowed_regs, so the call to QTI_SIP_SVC_SECURE_IO_WRITE_ID fails.
Add the address to the array to prevent this error.