### PR TITLE
fix(lemans_evk): move BL2 to pIMEM instead of system IMEM

### DIFF
--- a/plat/qti/hoya/lemans/lemans_evk/inc/platform_def.h
+++ b/plat/qti/hoya/lemans/lemans_evk/inc/platform_def.h
@@ -12,8 +12,8 @@
 #define MAX_IO_DEVICES			U(2)
 #define MAX_IO_BLOCK_DEVICES		U(1)
 
-#define BL2_BASE			0x14680000
-#define BL2_SIZE			0x80000
+#define BL2_BASE			0x1c00e000
+#define BL2_SIZE			0x100000
 #define BL2_LIMIT			(BL2_BASE + BL2_SIZE)
 
 #define BL31_BASE			0x1c200000


### PR DESCRIPTION
System IMEM starting range on most of Qcom platforms is reserved for crashdump diagnostic logs. So let's rather load BL2 on pIMEM instead to allow the existing crashdump feature supported by system IMEM to work.

fyi.. @zelvam95