### PR TITLE
feat(plat/qti): add ring buffer console driver

### DIFF
--- a/plat/qti/common/inc/qti_ringbuf_console.h
+++ b/plat/qti/common/inc/qti_ringbuf_console.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018,2020 The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef QTI_RINGBUF_CONSOLE_H
+#define QTI_RINGBUF_CONSOLE_H
+
+#include <drivers/console.h>
+#include <lib/utils_def.h>
+
+#define CONSOLE_RINGBUF_T_SIZE (U(0) * REGSZ)
+#define CONSOLE_RINGBUF_T_POS  (U(1) * REGSZ)
+#define CONSOLE_RINGBUF_T_BUF  (U(2) * REGSZ)
+
+#ifndef __ASSEMBLER__
+
+#define PLAT_QTI_RING_BUF_SIZE 0x1000
+
+typedef struct console_ringbuf {
+       u_register_t rb_size;
+       u_register_t rb_pos;
+       uint8_t      rb_buffer[PLAT_QTI_RING_BUF_SIZE];
+} console_ringbuf_t;
+
+
+int qti_console_ringbuf_register(console_t *console, uintptr_t ringbuf_base_addr);
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* QTI_RINGBUF_CONSOLE_H */

--- a/plat/qti/common/inc/tfa_bl31_shared_imem.h
+++ b/plat/qti/common/inc/tfa_bl31_shared_imem.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018-2020, 2025. The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TFA_BL31_SHARED_IMEM_H
+#define TFA_BL31_SHARED_IMEM_H
+
+#include <bl31qtilib_defs_plat.h>
+
+#define TFA_BL31_SHARED_IMEM_TFA_AREA_BASE      (SHARED_IMEM_BASE + 0x734 + 340)
+
+#define TFA_BL31_IMEM_ADDR(offset) \
+        (TFA_BL31_SHARED_IMEM_TFA_AREA_BASE + (offset))
+
+#define TFA_BL31_SHARED_IMEM_RING_BUF_BASE      TFA_BL31_IMEM_ADDR(0x0) /* 8 bytes */
+#define TFA_BL31_SHARED_IMEM_RING_BUF_SIZE      TFA_BL31_IMEM_ADDR(0x10) /* 4 bytes */
+
+/* Next available: TFA_BL31_IMEM_ADDR(0x18), 8-byte aligned */
+/* RESERVED until TFA_BL31_IMEM_ADDR(0x2c), 20 bytes available*/
+
+#endif /* TFA_BL31_SHARED_IMEM_H */

--- a/plat/qti/common/src/aarch64/qti_ringbuf_console.S
+++ b/plat/qti/common/src/aarch64/qti_ringbuf_console.S
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018,2020 The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm_macros.S>
+#include <console_macros.S>
+
+#include <platform_def.h>
+#include <qti_ringbuf_console.h>
+
+       .extern plat_qti_console_ring_buf;
+       .extern plat_qti_console_buf_size;
+/*
+ * This driver implements console logging into a ring buffer.
+ */
+
+       .globl qti_console_ringbuf_register
+
+       /* -----------------------------------------------
+        * int qti_console_ringbuf_register(console_t *console,
+        *                                  uintptr_t ringbuf_base_addr)
+        * Registers ringbuf console instance.
+        * In:  x0 - pointer to empty console_t struct
+        *      x1 - start address of ringbuf block.
+        * Out: x0 - 1 to indicate success
+        * Clobber list: x0, x1, x14
+        * -----------------------------------------------
+        */
+func qti_console_ringbuf_register
+       str     x1, [x0, #CONSOLE_T_BASE]       /* Save addr of ringbuf struct */
+       finish_console_register ringbuf putc=1, flush=0
+endfunc qti_console_ringbuf_register
+
+       /* -----------------------------------------------
+        * int qti_console_ringbuf_puts(int c, console_t *console)
+        * Writes a character to the ringbuf console.
+        * The character must be preserved in x0.
+        * In: x0 - character to be stored
+        *     x1 - pointer to console_t struct
+        * Clobber list: x1, x2, x16-x17 (per the porting guide)
+        * -----------------------------------------------
+        */
+func console_ringbuf_putc
+       /* set x1 = UART base. */
+       ldr     x1, [x1, #CONSOLE_T_BASE]
+       ldr     x2, [x1, #CONSOLE_RINGBUF_T_SIZE]
+       ldr     x16, [x1, #CONSOLE_RINGBUF_T_POS]
+       add     x17, x1, #CONSOLE_RINGBUF_T_BUF
+       add     x17, x17, x16
+       strb    w0, [x17]
+       add     x16, x16, #1
+       cmp     x16, x2
+       b.lt    1f
+       mov     x16, xzr
+
+1:
+       str     x16, [x1, #CONSOLE_RINGBUF_T_POS]
+       ret
+endfunc        console_ringbuf_putc
+
+       /* -----------------------------------------------
+        * int qti_console_ringbuf_flush(console_t *console)
+        * In:  x0 - pointer to console_t struct
+        * Out: x0 - 0 for success
+        * Clobber list: x0, x1
+        * -----------------------------------------------
+        */
+func console_ringbuf_flush
+       mov     w0, #0
+       ret
+endfunc console_ringbuf_flush

--- a/plat/qti/common/src/qti_bl31_setup.c
+++ b/plat/qti/common/src/qti_bl31_setup.c
@@ -28,8 +28,17 @@
 #include <qti_uart_console.h>
 #include <qtiseclib_interface.h>
 
-/* Variable to hold QTI UART configuration */
+#include <qti_ringbuf_console.h>
+#include <tfa_bl31_shared_imem.h>
+
+
+console_ringbuf_t g_qti_bl31_ringbuf = {
+       .rb_size = PLAT_QTI_RING_BUF_SIZE,
+};
+
+/* Variables to hold QTI UART and ring buffer configuration */
 static console_t g_qti_console_uart;
+static console_t g_qti_console_ringbuf;
 
 /*
  * Placeholder variables for copying the BL32 and Bl33 arguments that have been
@@ -60,6 +69,14 @@ void bl31_early_platform_setup(u_register_t from_bl2,
 	qti_console_uart_register(&g_qti_console_uart, PLAT_QTI_UART_BASE);
 	console_set_scope(&g_qti_console_uart, CONSOLE_FLAG_RUNTIME |
 			  CONSOLE_FLAG_BOOT | CONSOLE_FLAG_CRASH);
+
+	qti_console_ringbuf_register(&g_qti_console_ringbuf, (uintptr_t) &g_qti_bl31_ringbuf);
+	console_set_scope(&g_qti_console_ringbuf, CONSOLE_FLAG_RUNTIME);
+
+	/* Write the location and size of the ring buffer to shared imem */
+	*(uint64_t*)TFA_BL31_SHARED_IMEM_RING_BUF_BASE = (uint64_t)(g_qti_bl31_ringbuf.rb_buffer);
+	*(uint32_t*)TFA_BL31_SHARED_IMEM_RING_BUF_SIZE = (uint32_t)g_qti_bl31_ringbuf.rb_size;
+
 	/*
 	 * Tell BL31 where the non-trusted software image
 	 * is located and the entry state information

--- a/plat/qti/hoya/lemans/inc/bl31qtilib_defs_plat.h
+++ b/plat/qti/hoya/lemans/inc/bl31qtilib_defs_plat.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2021, The Linux Foundation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __BL31QTILIB_DEFS_PLAT_H__
+#define __BL31QTILIB_DEFS_PLAT_H__
+
+#define TFA_SHARED_MEMORY_BASE  0xD856A000
+#define TFA_SHARED_MEMORY_SIZE 0x00002000
+
+/*----------------------------------------------------------------------------*/
+/* SHARED_IMEM address space for mapping */
+/*----------------------------------------------------------------------------*/
+#define SHARED_IMEM_BASE 0x146D8000
+#define SHARED_IMEM_SIZE 0x00001000
+
+#endif /* __BL31QTILIB_DEFS_PLAT_H__ */

--- a/plat/qti/hoya/lemans/lemans_evk/platform.mk
+++ b/plat/qti/hoya/lemans/lemans_evk/platform.mk
@@ -88,6 +88,7 @@ BL31_SOURCES		+=	drivers/delay_timer/generic_delay_timer.c		\
 				${GICV3_SOURCES}					\
 				plat/common/plat_psci_common.c				\
 				$(PLAT_PATH)/common/src/$(ARCH)/qti_helpers.S		\
+				$(PLAT_PATH)/common/src/$(ARCH)/qti_ringbuf_console.S	\
 				$(PLAT_PATH)/common/src/pm_ps_hold.c			\
 				$(PLAT_PATH)/common/src/qti_bl31_setup.c		\
 				$(PLAT_PATH)/common/src/qti_gic_v3.c			\


### PR DESCRIPTION
Introduce the QTI ring buffer implementation and console driver. This commit provides the common implementation and Lemans-specific configuration of the ring buffer used to hold diagnostic information read by Crashscope.