### PR TITLE
feat(lemans): expose dcache flush all callback to QTISECLIB

### DIFF
--- a/plat/qti/hoya/qtiseclib/inc/qtiseclib_cb_interface.h
+++ b/plat/qti/hoya/qtiseclib/inc/qtiseclib_cb_interface.h
@@ -46,13 +46,14 @@ void qtiseclib_cb_udelay(uint32_t usec);
 
 void qtiseclib_cb_console_flush(void);
 
+void qtiseclib_cb_flush_dcache_all(void);
+
 #if QTI_SDI_BUILD
 int qtiseclib_cb_mmap_remove_dynamic_region(uintptr_t base_va, size_t size);
 int qtiseclib_cb_mmap_add_dynamic_region(unsigned long long base_pa,
 					 size_t size,
 					 qtiseclib_mmap_attr_t attr);
 
-void qtiseclib_cb_flush_dcache_all(void);
 void qtiseclib_cb_get_ns_ctx(qtiseclib_dbg_a64_ctxt_regs_type *ns_ctx);
 #endif
 

--- a/plat/qti/hoya/qtiseclib/src/qtiseclib_cb_interface.c
+++ b/plat/qti/hoya/qtiseclib/src/qtiseclib_cb_interface.c
@@ -126,6 +126,11 @@ void qtiseclib_cb_console_flush(void)
 	return console_flush();
 }
 
+void qtiseclib_cb_flush_dcache_all(void)
+{
+	dcsw_op_all(DCCISW);
+}
+
 #if QTI_SDI_BUILD
 void qtiseclib_cb_get_ns_ctx(qtiseclib_dbg_a64_ctxt_regs_type *qti_ns_ctx)
 {
@@ -180,11 +185,6 @@ void qtiseclib_cb_get_ns_ctx(qtiseclib_dbg_a64_ctxt_regs_type *qti_ns_ctx)
 	qti_ns_ctx->x30 = read_ctx_reg(get_gpregs_ctx(ctx), CTX_GPREG_LR);
 	qti_ns_ctx->sp_el0 =
 	    read_ctx_reg(get_gpregs_ctx(ctx), CTX_GPREG_SP_EL0);
-}
-
-void qtiseclib_cb_flush_dcache_all(void)
-{
-	dcsw_op_all(DCCISW);
 }
 
 int qtiseclib_cb_mmap_add_dynamic_region(unsigned long long base_pa,


### PR DESCRIPTION
Remove featurization of dcache flush all callback functionality ensuring that it is always available to QTISECLIB.

Change-Id: If8b2b4d8e83600bca006c90ce57c72d021c0b401