### PR TITLE
fix(clock): tolerate a NULL ICB client instead of asserting

### DIFF
--- a/drivers/qti/clock/clock_driver.c
+++ b/drivers/qti/clock/clock_driver.c
@@ -175,7 +175,11 @@ static int clock_enable_clock_group_internal(struct clock_group *group)
 			if (icb->icb == NULL) {
 				icb->icb = icbuarb_create_client(
 					icb->master, icb->slave);
-				assert(icb->icb != NULL);
+				if (icb->icb == NULL) {
+					WARN("clock: no ICB client %u->%u, skipping vote\n",
+						(unsigned int)icb->master, (unsigned int)icb->slave);
+					continue;
+				}
 			}
 
 			/*


### PR DESCRIPTION
icbuarb_create_client() can return NULL for a route (seen on lemans_evk enabling CLOCK_GROUP_INIT during BL31 setup). A debug build then aborts at clock_driver.c:178 assert(icb->icb != NULL); a release build compiles it out and boots, since icbuarb_issue_request() already returns false for a NULL handle. Warn and skip the vote instead, so debug matches release.

Refs #38.